### PR TITLE
Replace Spanish stream url

### DIFF
--- a/stream_transcriber/streams.py
+++ b/stream_transcriber/streams.py
@@ -82,7 +82,7 @@ SUPPORTED_STREAMS: Dict[str, SupportedStream] = {
         translation_languages=["en"],
     ),
     "spanish": SupportedStream(
-        url="https://22333.live.streamtheworld.com/CADENASERAAC_SC",
+        url="https://25493.live.streamtheworld.com/CADENASERAAC.aac",
         language="es",
         translation_languages=["en"],
     ),

--- a/stream_transcriber/streams.py
+++ b/stream_transcriber/streams.py
@@ -82,7 +82,7 @@ SUPPORTED_STREAMS: Dict[str, SupportedStream] = {
         translation_languages=["en"],
     ),
     "spanish": SupportedStream(
-        url="https://25493.live.streamtheworld.com/CADENASERAAC.aac",
+        url="https://25493.live.streamtheworld.com/CADENASERAAC_SC",
         language="es",
         translation_languages=["en"],
     ),


### PR DESCRIPTION
The streaming url for Cadena SER stoped working. The MR replaces the url with one that works.